### PR TITLE
Use specified image tags for demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ LATEST_IMAGE=$(IMAGE):latest
 export LOGSTASH_VERSION
 export LOGSTASH_DOWNLOAD_URL
 export VERSIONED_IMAGE
+export VERSION_TAG
 
 test: build
 	test -d venv || virtualenv --python=python3.5 venv

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -5,7 +5,7 @@
 version: '2'
 services:
   logstash:
-    image: docker.elastic.co/logstash/logstash:${LOGSTASH_VERSION}
+    image: docker.elastic.co/logstash/logstash:${VERSION_TAG}
     volumes:
       - ./examples/elastic-stack-demo:/usr/share/logstash/pipeline
     links:
@@ -22,10 +22,10 @@ services:
       - '9600:9600'
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${LOGSTASH_VERSION}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION_TAG}
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:${LOGSTASH_VERSION}
+    image: docker.elastic.co/kibana/kibana:${VERSION_TAG}
     ports: [ '5601:5601' ]
     links: [ elasticsearch ]
 


### PR DESCRIPTION
With the support for unified release artifacts we need a way for the
demo to support that as well.

Use the env var `VERSION_TAG` as the tag for all the stack images in the
demo docker-compose file. This is automatically set and exported by the
Makefile with logic honoring staging builds. If
`docker-compose.demo.yml` is used standalone without the Makefile, user
can `export VERSION_TAG=<stackversion>` or just leave undefined which
will revert to :latest.
