### PR TITLE
workdir added for shortened paths

### DIFF
--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -26,8 +26,6 @@ RUN groupadd --gid 1000 logstash && \
     adduser --uid 1000 --gid 1000 \
       --home-dir /usr/share/logstash --no-create-home \
       logstash
-      
-WORKDIR /usr/share/logstash
 
 # Add Logstash itself.
 RUN curl -Lo - {{ url_root }}/{{ tarball }} | \
@@ -35,6 +33,8 @@ RUN curl -Lo - {{ url_root }}/{{ tarball }} | \
     mv /usr/share/logstash-{{ elastic_version }} /usr/share/logstash && \
     chown --recursive logstash:logstash /usr/share/logstash/ && \
     ln -s /usr/share/logstash /opt/logstash
+
+WORKDIR /usr/share/logstash
 
 ENV ELASTIC_CONTAINER true
 ENV PATH=/usr/share/logstash/bin:$PATH

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -41,10 +41,10 @@ ENV PATH=/usr/share/logstash/bin:$PATH
 
 # Provide a minimal configuration, so that simple invocations will provide
 # a good experience.
-ADD config/logstash-{{ image_flavor }}.yml /usr/share/logstash/config/logstash.yml
-ADD config/log4j2.properties /usr/share/logstash/config/
-ADD pipeline/default.conf /usr/share/logstash/pipeline/logstash.conf
-RUN chown --recursive logstash:logstash /usr/share/logstash/config/ /usr/share/logstash/pipeline/
+ADD config/logstash-{{ image_flavor }}.yml config/logstash.yml
+ADD config/log4j2.properties config/
+ADD pipeline/default.conf pipeline/logstash.conf
+RUN chown --recursive logstash:logstash config/ pipeline/
 
 # Ensure Logstash gets a UTF-8 locale by default.
 ENV LANG='en_US.UTF-8' LC_ALL='en_US.UTF-8'

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -26,6 +26,8 @@ RUN groupadd --gid 1000 logstash && \
     adduser --uid 1000 --gid 1000 \
       --home-dir /usr/share/logstash --no-create-home \
       logstash
+      
+WORKDIR /usr/share/logstash
 
 # Add Logstash itself.
 RUN curl -Lo - {{ url_root }}/{{ tarball }} | \


### PR DESCRIPTION
Kibana and Elasticsearch docker repositories has workdir and this really help while extending. But logstash not. I added workdir to template but I don't know how I can test. I can test with shortened paths if you tell me a way to test. For this reason, I have not removed all the `/usr/share/logstash` paths, yet.