### PR TITLE
Replace USER command with gosu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ DEFAULT_IMAGE_FLAVOR ?= x-pack
 IMAGE_TAG := $(ELASTIC_REGISTRY)/logstash/logstash
 HTTPD ?= logstash-docker-artifact-server
 
+PYTHON := python3.5
 FIGLET := pyfiglet -w 160 -f puffy
 
 all: build test
@@ -81,7 +82,7 @@ push: test
 
 # The tests are written in Python. Make a virtualenv to handle the dependencies.
 venv: requirements.txt
-	test -d venv || virtualenv --python=python3.5 venv
+	test -d venv || virtualenv --python=$(PYTHON) venv
 	pip install -r requirements.txt
 	touch venv
 

--- a/build/logstash/bin/docker-entrypoint
+++ b/build/logstash/bin/docker-entrypoint
@@ -6,8 +6,16 @@
 # host system.
 env2yaml /usr/share/logstash/config/logstash.yml
 
+# Default to running logstash if no arguments are given, or if first argument
+# starts with a -
 if [[ -z $1 ]] || [[ ${1:0:1} == '-' ]] ; then
-  exec logstash "$@"
-else
-  exec "$@"
+  set -- logstash "$@"
 fi
+
+# Change to the logstash user if we're running the logstash command, and
+# not already running as an unprivileged user
+if [ "$1" = 'logstash' -a "$(id -u)" = '0' ]; then
+    set -- gosu logstash "$@"
+fi
+
+exec "$@"

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -27,6 +27,17 @@ RUN groupadd --gid 1000 logstash && \
       --home-dir /usr/share/logstash --no-create-home \
       logstash
 
+# grab gosu for easy step-down from root
+# https://github.com/tianon/gosu/releases
+ENV GOSU_VERSION 1.10
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && rm -r /root/.gnupg/ \
+    && chmod +x /usr/local/bin/gosu
+
 # Add Logstash itself.
 RUN curl -Lo - {{ url_root }}/{{ tarball }} | \
     tar zxf - -C /usr/share && \
@@ -53,9 +64,8 @@ ENV LANG='en_US.UTF-8' LC_ALL='en_US.UTF-8'
 ADD bin/docker-entrypoint /usr/local/bin/
 RUN chmod 0755 /usr/local/bin/docker-entrypoint
 
-USER logstash
 {% if image_flavor != 'oss' %}
-RUN cd /usr/share/logstash && logstash-plugin install {{ x_pack }}
+RUN cd /usr/share/logstash && gosu logstash logstash-plugin install {{ x_pack }}
 {% endif %}
 ADD env2yaml/env2yaml /usr/local/bin/
 


### PR DESCRIPTION
By using gosu, the entrypoint runs as root instead of the unprivileged
logstash user. This allows the entrypoint to run as root, while running
logstash itself as an unprivileged user.

This works similarly to the [original image from docker-library][1].

Also including a patch to allow python executable to be overridden for make.

[1]: https://github.com/docker-library/logstash/blob/5a25e180a82989857ee4ef036686523be210f619/5/docker-entrypoint.sh
