### PR TITLE
Allow Python3 versions >3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,9 +81,20 @@ push: test
 
 # The tests are written in Python. Make a virtualenv to handle the dependencies.
 venv: requirements.txt
-	test -d venv || virtualenv --python=python3.5 venv
-	pip install -r requirements.txt
-	touch venv
+	@if [ -z $$PYTHON3 ]; then\
+	    PY3_MINOR_VER=`python3 --version 2>&1 | cut -d " " -f 2 | cut -d "." -f 2`;\
+	    if (( $$PY3_MINOR_VER < 5 )); then\
+		echo "Couldn't find python3 in \$PATH that is >=3.5";\
+		echo "Please install python3.5 or later or explicity define the python3 executable name with \$PYTHON3";\
+		echo "Exiting here";\
+		exit 1;\
+	    else\
+		export PYTHON3="python3.$$PY3_MINOR_VER";\
+	   fi;\
+	fi;\
+	test -d venv || virtualenv --python=$$PYTHON3 venv;\
+	pip install -r requirements.txt;\
+	touch venv;\
 
 # Make a Golang container that can compile our env2yaml tool.
 golang:


### PR DESCRIPTION
Same work as done in the other *-docker repos, to prevent failures on
platforms where newer versions of Python 3 are installed.