### PR TITLE
consistent file system permissions

### DIFF
--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -31,7 +31,6 @@ RUN groupadd --gid 1000 logstash && \
 RUN curl -Lo - {{ url_root }}/{{ tarball }} | \
     tar zxf - -C /usr/share && \
     mv /usr/share/logstash-{{ elastic_version }} /usr/share/logstash && \
-    chown --recursive logstash:logstash /usr/share/logstash/ && \
     chown -R logstash:root /usr/share/logstash && \
     chmod -R g=u /usr/share/logstash && \
     find /usr/share/logstash -type d -exec chmod g+s {} \; && \

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -47,7 +47,8 @@ ADD config/pipelines.yml config/pipelines.yml
 ADD config/logstash-{{ image_flavor }}.yml config/logstash.yml
 ADD config/log4j2.properties config/
 ADD pipeline/default.conf pipeline/logstash.conf
-RUN chown --recursive logstash:root config/ pipeline/
+RUN chown --recursive logstash:root config/ pipeline/ && \
+    chmod -R g=u config/ pipeline/
 
 # Ensure Logstash gets a UTF-8 locale by default.
 ENV LANG='en_US.UTF-8' LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
Removing redundant `chmod` line as well making config files same mode as
the rest of the directory. This helps container runtimes that run with a 
randomly generated user id but `root` group (openshift/kubernetes) to 
directly run this image without modifications.