### PR TITLE
Add writeable permission to config files

### DIFF
--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -49,6 +49,7 @@ ADD config/logstash-{{ image_flavor }}.yml config/logstash.yml
 ADD config/log4j2.properties config/
 ADD pipeline/default.conf pipeline/logstash.conf
 RUN chown --recursive logstash:root config/ pipeline/
+RUN chmod --recursive g+w config/ pipeline/
 
 # Ensure Logstash gets a UTF-8 locale by default.
 ENV LANG='en_US.UTF-8' LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
This lets the `env2yml` tool update the config files when the container
is being used on Openshift where the user and group are unknown at
build time.

Similar in spirit to #113 but I only saw that PR after creating this one :-/

* ~~do you have a link to the CLA that needs signing?~~ CLA bot that runs as a check on this PR links you
* is `master` the correct target for this (and for my education how does it get ported to all the other branches)?

Let me know what you think.